### PR TITLE
Update deepSleepMgr.h

### DIFF
--- a/include/deepSleepMgr.h
+++ b/include/deepSleepMgr.h
@@ -141,6 +141,7 @@ typedef enum _DeepSleep_WakeupReason_t
    DEEPSLEEP_WAKEUPREASON_CEC,              /*!< Deepsleep Wakeup Reason is HDMI CEC Failure event */
    DEEPSLEEP_WAKEUPREASON_PRESENCE,         /*!< Deepsleep Wakeup Reason is Motion Detection event */
    DEEPSLEEP_WAKEUPREASON_VOICE,            /*!< Deepsleep Wakeup Reason is User Voice event */
+   DEEPSLEEP_WAKEUPREASON_KERNEL_PANIC,     /*!< Deepsleep Wakeup Reason is kernel panic */
    DEEPSLEEP_WAKEUPREASON_UNKNOWN,          /*!< Deepsleep Wakeup Reason is Unknown Reason event */
    DEEPSLEEP_WAKEUPREASON_MAX               /*!< Out of range - required to be the last item of the enum */
 }DeepSleep_WakeupReason_t;


### PR DESCRIPTION
RDK-45863: Deepsleep and Power Manager headers copied 

Reason for change: 
Missing enum added 
Test Procedure: None
Risks: Low

Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>